### PR TITLE
fix: aws_lb name can't be longer than 32 characters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 resource "aws_lb" "nlb" {
-  name                             = local.name
+  name                             = substr(local.name, 0, 32) # "name" cannot be longer than 32 characters
   internal                         = var.internal
   load_balancer_type               = "network"
   subnets                          = var.public_subnets


### PR DESCRIPTION
```
│ Error: "name" cannot be longer than 32 characters: "crypto-v2-stage-us-east-1-traefik"
│
│   with module.eks_v2_crypto.module.nlb["traefik"].aws_lb.nlb,
│   on .terraform/modules/eks_v2_crypto.nlb/main.tf line 7, in resource "aws_lb" "nlb":
│    7:   name                             = local.name
```