### PR TITLE
fix: remove region from cluster name to build name fo LB resources

### DIFF
--- a/datasources.tf
+++ b/datasources.tf
@@ -1,0 +1,1 @@
+data "aws_region" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,8 @@
 locals {
-  name       = join("-", compact([var.cluster_name, var.name_suffix]))
-  short_name = substr(local.name, 0, 26) # Shorter name used to bypass 32 char limitation for target groups
+  # cluter name without region
+  short_cluster_name = replace(var.cluster_name, "-${data.aws_region.current.name}", "")
+  name               = join("-", compact([local.short_cluster_name, var.name_suffix]))
+  short_name         = substr(local.name, 0, 26) # Shorter name used to bypass 32 char limitation for target groups
 }
 
 resource "aws_lb" "nlb" {


### PR DESCRIPTION
We don't need the region name in the names o LBs because LBs are related to the region.

This PR is tested. I run terraform apply twice, and the second time it showed no changes.