### PR TITLE
Expose a variable to customise health check port

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,10 @@ No modules.
 | <a name="input_application"></a> [application](#input\_application) | (namespace/app) - Name of application which will be connected to this NLB | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster will be used as suffix to all resources | `string` | n/a | yes |
 | <a name="input_extra_listeners"></a> [extra\_listeners](#input\_extra\_listeners) | List with configuration for additional listeners | <pre>list(object({<br>    name              = string<br>    port              = string<br>    protocol          = optional(string, "TCP")<br>    target_group_port = number<br>  }))</pre> | `[]` | no |
+| <a name="input_health_check_port"></a> [health\_check\_port](#input\_health\_check\_port) | Port used for health check for listener | `string` | `"traffic-port"` | no |
 | <a name="input_internal"></a> [internal](#input\_internal) | Set NLB to be internal (available only within VPC) | `bool` | n/a | yes |
 | <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix) | Part of the name used to differentiate NLBs for multiple traefik instances | `string` | `""` | no |
-| <a name="input_plain_health_check_port"></a> [plain\_health\_check\_port](#input\_plain\_health\_check\_port) | Port used for health check for plain listener | `string` | `"traffic-port"` | no |
 | <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | List of public subnets to use | `list(string)` | n/a | yes |
-| <a name="input_tls_health_check_port"></a> [tls\_health\_check\_port](#input\_tls\_health\_check\_port) | Port used for health check for TLS listener | `string` | `"traffic-port"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the NLB will be deployed | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ resource "aws_lb_target_group" "tls" {
     enabled             = true
     healthy_threshold   = 3
     interval            = 10
-    port                = var.tls_health_check_port
+    port                = var.health_check_port
     protocol            = "TCP"
     unhealthy_threshold = 3
   }
@@ -115,7 +115,7 @@ resource "aws_lb_target_group" "plain" {
     enabled             = true
     healthy_threshold   = 3
     interval            = 10
-    port                = var.plain_health_check_port
+    port                = var.health_check_port
     protocol            = "TCP"
     unhealthy_threshold = 3
   }

--- a/variables.tf
+++ b/variables.tf
@@ -52,14 +52,8 @@ variable "extra_listeners" {
   default = []
 }
 
-variable "tls_health_check_port" {
-    description = "Port used for health check for TLS listener"
-    type        = string
-    default     = "traffic-port"
-}
-
-variable "plain_health_check_port" {
-    description = "Port used for health check for plain listener"
+variable "health_check_port" {
+    description = "Port used for health check for listener"
     type        = string
     default     = "traffic-port"
 }


### PR DESCRIPTION
Health check ports are currently hardcoded to `traffic-port`, but we need a way to customise them so to be usable with other type of services