### PR TITLE
[B-1460] Allow configuring the name of the NLB

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ No modules.
 | <a name="input_application"></a> [application](#input\_application) | (namespace/app) - Name of application which will be connected to this NLB | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster will be used as suffix to all resources | `string` | n/a | yes |
 | <a name="input_extra_listeners"></a> [extra\_listeners](#input\_extra\_listeners) | List with configuration for additional listeners | <pre>list(object({<br>    name              = string<br>    port              = string<br>    protocol          = optional(string, "TCP")<br>    target_group_port = number<br>  }))</pre> | `[]` | no |
-| <a name="input_health_check_port"></a> [health\_check\_port](#input\_health\_check\_port) | Port used for health check for listener | `string` | `"traffic-port"` | no |
+| <a name="input_health_check_port"></a> [health\_check\_port](#input\_health\_check\_port) | Port used for health check for listener | `number` | `-1` | no |
 | <a name="input_internal"></a> [internal](#input\_internal) | Set NLB to be internal (available only within VPC) | `bool` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the NLB, overrides default naming | `string` | `""` | no |
 | <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix) | Part of the name used to differentiate NLBs for multiple traefik instances | `string` | `""` | no |
 | <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | List of public subnets to use | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the NLB will be deployed | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # cluter name without region
   short_cluster_name = replace(var.cluster_name, "-${data.aws_region.current.name}", "")
-  name               = join("-", compact([local.short_cluster_name, var.name_suffix]))
+  name               = var.name == "" ? join("-", compact([local.short_cluster_name, var.name_suffix])) : var.name
   short_name         = substr(local.name, 0, 26) # Shorter name used to bypass 32 char limitation for target groups
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "cluster_name" {
   type        = string
 }
 
+variable "name" {
+  description = "Name of the NLB, overrides default naming"
+  type        = string
+  default     = ""
+}
+
 variable "application" {
   description = "(namespace/app) - Name of application which will be connected to this NLB"
   type        = string


### PR DESCRIPTION
The module currently defaults the name of the NLB to the join of the cluster name (minus the region) and the name suffix. 
Then it truncates that to 26 chars to get the name of the target group.

This causes problems when we provision several NLBs for the same cluster if the name suffix is quite long. 
E.g. in the case of MPC, having cluster name `"mpc-2-stage-eu-central-1"` and the name suffix `"participant-left-1"` produces a target group name `mpc-2-stage-participant-le-tls` and this collides with the target group created for the NLB with name suffix `"participant-left-2"`.

In this PR we add a new variable called `name` that allows to setup a name for the NLB without defaulting to the one built up in the module.