### PR TITLE
fix: set proper validation for name and name_suffix

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "name" {
   type        = string
   default     = ""
   validation {
-    condition     = can(regex("^[a-z0-9-]+$", var.name))
+    condition     = var.name == "" ? true : can(regex("^[a-z0-9-]+$", var.name))
     error_message = "Name must be lowercase alphanumeric characters or hyphens"
   }
 }
@@ -79,7 +79,7 @@ variable "name_suffix" {
   type        = string
   default     = ""
   validation {
-    condition     = can(regex("^[a-z0-9-]+$", var.name_suffix))
+    condition     = var.name_suffix == "" ? true : can(regex("^[a-z0-9-]+$", var.name_suffix))
     error_message = "Name suffix must be lowercase alphanumeric characters or hyphens"
   }
 }


### PR DESCRIPTION
Requestor: @danielllek
Tested: yes
Description: add missing condition to allow empty `name` and `name_suffix` to work on default empty values