### PR TITLE
INFRA-3898: Fix flapping HC

### DIFF
--- a/additional_listeners.tf
+++ b/additional_listeners.tf
@@ -38,7 +38,7 @@ resource "aws_lb_target_group" "extra" {
     enabled             = true
     healthy_threshold   = 3
     interval            = 10
-    port                = "traffic-port"
+    port                = each.value.target_group_port
     protocol            = "TCP"
     unhealthy_threshold = 3
   }


### PR DESCRIPTION
INFRA-3898

Fix flapping HC
AWS LB controller sets hc port to exact value, not `traffic-port`
