### PR TITLE
INFRA-4261 Pin GitHub Actions to specific commit SHA

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,11 +14,11 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         name: Checkout source code
 
       - name: Render terraform docs inside the README.md and push changes back to main branch
-        uses: terraform-docs/gh-actions@v1.3.0
+        uses: terraform-docs/gh-actions@aeae0038ed47a547e0c0fca5c059d3335f48fb25
 
       # fix to terraform-docs action change ownership of files
       - name: Update ownership of files
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check-existence.outputs.branches == ''
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
           title: Update terraform docs
           branch: generated-docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/relyance-sci.yml
+++ b/.github/workflows/relyance-sci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Pull and run SCI binary
         run: |-

--- a/.github/workflows/terraform-test.yml
+++ b/.github/workflows/terraform-test.yml
@@ -10,4 +10,4 @@ jobs:
         uses: actions/checkout@master
 
       - name: terraform test
-        uses: dflook/terraform-test@v1
+        uses: dflook/terraform-test@58481fc46588861db38966e076b8481402817b91

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -10,16 +10,16 @@ jobs:
     runs-on: [self-hosted, amd64]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         name: Checkout source code
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         name: Cache plugin dir
         with:
           path: ~/.tflint.d/plugins
           key: tflint-${{ hashFiles('.tflint.hcl') }}
 
-      - uses: terraform-linters/setup-tflint@v4
+      - uses: terraform-linters/setup-tflint@6e87008f9dd1fe3e34e66aca6c97b4a69f72a7f4
         name: Setup TFLint
         with:
           tflint_version: v0.42.2

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -14,11 +14,11 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         name: Checkout source code
 
       - name: tfsec
-        uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
+        uses: aquasecurity/tfsec-pr-commenter-action@7a44c5dcde5dfab737363e391800629e27b6376b
         with:
           tfsec_version: v1.28.1
           github_token: ${{ github.token }}


### PR DESCRIPTION
Requestor/Issue: #incident-216
Tested (yes/no): yes
Description/Why: This pull request includes several updates to various GitHub Actions and workflows to use specific commit SHAs for the actions, ensuring stability and security.