### PR TITLE
INFRA-4974 Switch to ubuntu-latest GitHub runners

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   docs:
     name: docs
-    runs-on: arc-large-arm64-runner
+    runs-on: ubuntu-latest
 
     permissions:
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   update_release_draft:
     name: Update Release Draft
-    runs-on: arc-large-arm64-runner
+    runs-on: ubuntu-latest
 
     permissions:
       contents: write

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -4,10 +4,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   tflint:
     name: tflint
-    runs-on: arc-large-arm64-runner
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -4,10 +4,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   tfsec:
     name: tfsec
-    runs-on: arc-large-amd64-runner
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to standardize the runner environment and permissions across multiple workflows. The most important changes include switching from custom runners to `ubuntu-latest` and adding or modifying permissions for specific workflows.