### PR TITLE
remove hyphens in the end of lb name, it's not allowed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 resource "aws_lb" "nlb" {
-  name                             = substr(local.name, 0, 32) # "name" cannot be longer than 32 characters
+  name                             = trimsuffix(substr(local.name, 0, 32), "-") # "name" cannot be longer than 32 characters and cannot end with "-"
   internal                         = var.internal
   load_balancer_type               = "network"
   subnets                          = length(var.private_subnets) > 0 ? var.private_subnets : var.public_subnets


### PR DESCRIPTION
Requestor/Issue: @tcharewicz
Tested (yes/no): no, this PR is a test
Description/Why: While create EKS cluster for world-chat-service-prod in eu-west-1 regions, I have a error related to the name of ALB where it's end with hyphens. Link to TFE run https://tfe.worldcoin.dev/app/TFH/workspaces/world-chat-service-prod-eu-west-1/runs/run-7mf59FiKDk8zwZWg and screenshot for it.

<img width="1079" height="143" alt="Screenshot 2025-08-11 at 08 07 52" src="https://github.com/user-attachments/assets/de720358-452a-4d54-8612-c90fa79b2294" />

Description for Name variable for resource
name - (Optional) Name of the LB. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified, Terraform will autogenerate a name beginning with tf-lb.

This Pull Request remove hyphens from the end of LB name, once.