### PR TITLE
INFRA-6074: Add configurable `tag_prefix` and `tag_stack` for Gateway API support

### DIFF
--- a/additional_listeners.tf
+++ b/additional_listeners.tf
@@ -11,7 +11,7 @@ resource "aws_lb_listener" "extra" {
   }
 
   tags = merge(local.default_tags, {
-    "service.k8s.aws/resource" = each.value.port
+    "${var.tag_prefix}/resource" = each.value.port
   })
 
   lifecycle {
@@ -31,7 +31,7 @@ resource "aws_lb_target_group" "extra" {
   target_type = "ip"
 
   tags = merge(local.default_tags, {
-    "service.k8s.aws/resource" = format("%s:%s", var.application, each.value.port)
+    "${var.tag_prefix}/resource" = format("%s:%s", var.application, each.value.port)
   })
 
   health_check {

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
   default_tags = {
-    "elbv2.k8s.aws/cluster" = var.cluster_name
-    "service.k8s.aws/stack" = var.application
+    "elbv2.k8s.aws/cluster"   = var.cluster_name
+    "${var.tag_prefix}/stack" = var.tag_stack != "" ? var.tag_stack : var.application
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "aws_lb" "nlb" {
   enable_deletion_protection       = var.enable_deletion_protection
 
   tags = merge(local.default_tags, {
-    "service.k8s.aws/resource" = "LoadBalancer"
+    "${var.tag_prefix}/resource" = "LoadBalancer"
   })
 
   security_groups = [aws_security_group.nlb.id]
@@ -47,7 +47,7 @@ resource "aws_lb_listener" "tls" {
   }
 
   tags = merge(local.default_tags, {
-    "service.k8s.aws/resource" = "443"
+    "${var.tag_prefix}/resource" = "443"
   })
 
   lifecycle {
@@ -108,7 +108,7 @@ resource "aws_lb_listener" "plain" {
   }
 
   tags = merge(local.default_tags, {
-    "service.k8s.aws/resource" = "80"
+    "${var.tag_prefix}/resource" = "80"
   })
 
   lifecycle {
@@ -131,7 +131,7 @@ resource "aws_lb_target_group" "tls" {
   target_type = "ip"
 
   tags = merge(local.default_tags, {
-    "service.k8s.aws/resource" = "${var.application}:443"
+    "${var.tag_prefix}/resource" = "${var.application}:443"
   })
 
   health_check {
@@ -169,7 +169,7 @@ resource "aws_lb_target_group" "plain" {
   target_type = "ip"
 
   tags = merge(local.default_tags, {
-    "service.k8s.aws/resource" = "${var.application}:80"
+    "${var.tag_prefix}/resource" = "${var.application}:80"
   })
 
   health_check {

--- a/variables.tf
+++ b/variables.tf
@@ -200,3 +200,15 @@ variable "enable_deletion_protection" {
   type        = bool
   default     = true
 }
+
+variable "tag_prefix" {
+  description = "Tag key prefix for LBC resource/stack tags (e.g. service.k8s.aws for Service LB, gateway.k8s.aws.nlb for Gateway API)"
+  type        = string
+  default     = "service.k8s.aws"
+}
+
+variable "tag_stack" {
+  description = "Override the computed stack tag value (default: var.application)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-6074/add-configurable-tag-prefix-and-tag-stack-for-gateway-api-support-nlb
Tested (yes/no): yes
Description/Why: AWS LBC tags NLB resources with `service.k8s.aws` prefix when they are created through a Kubernetes Service. Gateway API uses a different prefix (`gateway.k8s.aws.nlb`) so pre-created NLBs need configurable tags for LBC to recognize them.