### PR TITLE
chore: add tfsec workflow

### DIFF
--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,27 +1,27 @@
-name: Terraform
+name: Terraform TFSec
 on:
   pull_request:
-    branches:
-      - main
-
-permissions:
-  contents: read
+    branches: [main]
+    paths:
+      - "**/*.tf"
 
 jobs:
   tfsec:
     name: tfsec
-    runs-on: ubuntu-latest
+    runs-on:
+      group: arc-large-amd64-runner
 
     permissions:
       contents: read
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        name: Checkout source code
-
+      - name: Clone repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: tfsec
         uses: aquasecurity/tfsec-pr-commenter-action@7a44c5dcde5dfab737363e391800629e27b6376b
         with:
+          # --ignore-hcl-errors to avoid error on terraform above 1.5
+          tfsec_args: --force-all-dirs --ignore-hcl-errors
           tfsec_version: v1.28.14
-          github_token: ${{ github.token }}
+          github_token: ${{ secrets.GIT_HUB_TOKEN }}


### PR DESCRIPTION
## Description
  This PR adds the tfsec-pr-commenter.yml workflow from the infrastructure repository as tfsec.yml.

  ## Changes
  - Copied `.github/workflows/tfsec-pr-commenter.yml` to `.github/workflows/tfsec.yml`

  ## Testing
  - Manual run of this copy workflow should create PRs in target repositories

  ## References
  - Source: worldcoin/infrastructure repository
  - Workflow source: `.github/workflows/tfsec-pr-commenter.yml`
  - Workflow destination: `.github/workflows/tfsec.yml`