### PR TITLE
INFRA-6098: Add support for custom cluster tag

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,8 @@
 locals {
+  cluster_tag = var.cluster_tag != "" ? var.cluster_tag : var.cluster_name
+
   default_tags = {
-    "elbv2.k8s.aws/cluster"   = var.cluster_name
+    "elbv2.k8s.aws/cluster"   = local.cluster_tag
     "${var.tag_prefix}/stack" = var.tag_stack != "" ? var.tag_stack : var.application
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -212,3 +212,9 @@ variable "tag_stack" {
   type        = string
   default     = ""
 }
+
+variable "cluster_tag" {
+  description = "Value for the elbv2.k8s.aws/cluster tag. Defaults to cluster_name. Use when the tag must differ from the name used to construct the LB name (e.g. Gateway API where the LB name prefix is trimmed but the tag must match the LBC --cluster-name)."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-6098/add-support-for-custom-cluster-tag-in-albnlb-modules
Tested (yes/no): yes
Description/Why: 
The LB name prefix may be shortened (e.g., via `gateway_api_lb_name_prefix`) to meet the **32**-character AWS limit, but the tag must exactly match the LBC `--cluster-name` for the controller to discover and adopt the load balancer.

The LBC discovers existing load balancers exclusively via tag filtering (`elbv2.k8s.aws/cluster` + `<tagPrefix>/stack`), not by loadBalancerName. If the tag does not match `--cluster-name`, the LBC will not find the existing load balancer and will attempt to create a new one, resulting in a name collision.