### PR TITLE
INFRA-6096: make acm_arn optional when default TLS listener is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,34 @@ module "nlb" {
   public_subnets = var.vpc_config.public_subnets
 }
 ```
+
+When `create_default_tls_listener = false`, `acm_arn` can be omitted:
+
+```terraform
+module "nlb" {
+  source = "github.com/worldcoin/terraform-aws-nlb?ref=v1.5.0"
+
+  cluster_name                 = var.name
+  application                  = "gateway-api/gateway"
+  internal                     = false
+  create_default_tls_listener  = false
+
+  vpc_id         = var.vpc_config.vpc_id
+  public_subnets = var.vpc_config.public_subnets
+}
+```
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.14.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.14.0 |
 
 ## Modules
@@ -38,7 +54,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_lb.nlb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb_listener.extra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.plain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
@@ -53,28 +69,33 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_acm_arn"></a> [acm\_arn](#input\_acm\_arn) | ARN for ACM certificate used for TLS | `string` | n/a | yes |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_acm_arn"></a> [acm\_arn](#input\_acm\_arn) | ARN for ACM certificate used for TLS. Required when the default TLS listener is enabled. | `string` | `null` | no |
 | <a name="input_acm_extra_arns"></a> [acm\_extra\_arns](#input\_acm\_extra\_arns) | ARNs of ACM certificates used for TLS, attached as additional certificates to the main NLB | `list(string)` | `[]` | no |
 | <a name="input_application"></a> [application](#input\_application) | (namespace/app) - Name of application which will be connected to this NLB | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster will be used as suffix to all resources | `string` | n/a | yes |
-| <a name="input_create_default_listeners"></a> [create\_default\_listeners](#input\_create\_default\_listeners) | If true, default listeners (80,442) will be created | `bool` | `true` | no |
+| <a name="input_cluster_tag"></a> [cluster\_tag](#input\_cluster\_tag) | Value for the elbv2.k8s.aws/cluster tag. Defaults to cluster\_name. Use when the tag must differ from the name used to construct the LB name (e.g. Gateway API where the LB name prefix is trimmed but the tag must match the LBC --cluster-name). | `string` | `""` | no |
+| <a name="input_create_default_listeners"></a> [create\_default\_listeners](#input\_create\_default\_listeners) | If true, default listeners will be created | `bool` | `true` | no |
+| <a name="input_create_default_plain_listener"></a> [create\_default\_plain\_listener](#input\_create\_default\_plain\_listener) | If true, default listener (80) will be created (ANDed with create\_default\_listeners) | `bool` | `true` | no |
+| <a name="input_create_default_tls_listener"></a> [create\_default\_tls\_listener](#input\_create\_default\_tls\_listener) | If true, tls listener (443) will be created (ANDed with create\_default\_listeners) | `bool` | `true` | no |
 | <a name="input_enable_deletion_protection"></a> [enable\_deletion\_protection](#input\_enable\_deletion\_protection) | If true, deletion of the load balancer will be disabled via the AWS API | `bool` | `true` | no |
-| <a name="input_extra_listeners"></a> [extra\_listeners](#input\_extra\_listeners) | List with configuration for additional listeners | <pre>list(object({<br>    name              = string<br>    port              = string<br>    protocol          = optional(string, "TCP")<br>    target_group_port = number<br>  }))</pre> | `[]` | no |
+| <a name="input_extra_listeners"></a> [extra\_listeners](#input\_extra\_listeners) | List with configuration for additional listeners | <pre>list(object({<br/>    name              = string<br/>    port              = string<br/>    protocol          = optional(string, "TCP")<br/>    target_group_port = number<br/>  }))</pre> | `[]` | no |
 | <a name="input_health_check_port"></a> [health\_check\_port](#input\_health\_check\_port) | Port used for health check for listener | `number` | `-1` | no |
-| <a name="input_ingress_sg_rules"></a> [ingress\_sg\_rules](#input\_ingress\_sg\_rules) | The security group rules to allow ingress from. | <pre>set(object({<br>    description      = optional(string, "")<br>    protocol         = optional(string, "tcp")<br>    port             = optional(number, 443)<br>    security_groups  = optional(list(string))<br>    cidr_blocks      = optional(list(string))<br>    ipv6_cidr_blocks = optional(list(string))<br>  }))</pre> | <pre>[<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "description": "allow http from anywhere",<br>    "port": 80<br>  },<br>  {<br>    "description": "allow http from anywhere",<br>    "ipv6_cidr_blocks": [<br>      "::/0"<br>    ],<br>    "port": 80<br>  },<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "description": "allow https from anywhere",<br>    "port": 443<br>  },<br>  {<br>    "description": "allow https from anywhere",<br>    "ipv6_cidr_blocks": [<br>      "::/0"<br>    ],<br>    "port": 443<br>  }<br>]</pre> | no |
+| <a name="input_ingress_sg_rules"></a> [ingress\_sg\_rules](#input\_ingress\_sg\_rules) | The security group rules to allow ingress from. | <pre>set(object({<br/>    description      = optional(string, "")<br/>    protocol         = optional(string, "tcp")<br/>    port             = optional(number, 443)<br/>    security_groups  = optional(list(string))<br/>    cidr_blocks      = optional(list(string))<br/>    ipv6_cidr_blocks = optional(list(string))<br/>  }))</pre> | <pre>[<br/>  {<br/>    "cidr_blocks": [<br/>      "0.0.0.0/0"<br/>    ],<br/>    "description": "allow http from anywhere",<br/>    "port": 80<br/>  },<br/>  {<br/>    "description": "allow http from anywhere",<br/>    "ipv6_cidr_blocks": [<br/>      "::/0"<br/>    ],<br/>    "port": 80<br/>  },<br/>  {<br/>    "cidr_blocks": [<br/>      "0.0.0.0/0"<br/>    ],<br/>    "description": "allow https from anywhere",<br/>    "port": 443<br/>  },<br/>  {<br/>    "description": "allow https from anywhere",<br/>    "ipv6_cidr_blocks": [<br/>      "::/0"<br/>    ],<br/>    "port": 443<br/>  }<br/>]</pre> | no |
 | <a name="input_internal"></a> [internal](#input\_internal) | Set NLB to be internal (available only within VPC) | `bool` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of the NLB, overrides default naming | `string` | `""` | no |
 | <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix) | Part of the name used to differentiate NLBs for multiple traefik instances | `string` | `""` | no |
 | <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | List of private subnets to use | `list(string)` | `[]` | no |
 | <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | List of public subnets to use | `list(string)` | `[]` | no |
+| <a name="input_tag_prefix"></a> [tag\_prefix](#input\_tag\_prefix) | Tag key prefix for LBC resource/stack tags (e.g. service.k8s.aws for Service LB, gateway.k8s.aws.nlb for Gateway API) | `string` | `"service.k8s.aws"` | no |
+| <a name="input_tag_stack"></a> [tag\_stack](#input\_tag\_stack) | Override the computed stack tag value (default: var.application) | `string` | `""` | no |
 | <a name="input_tls_listener_version"></a> [tls\_listener\_version](#input\_tls\_listener\_version) | Minimum TLS version served by TLS listener | `string` | `"1.3"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the NLB will be deployed | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the NLB. |
 | <a name="output_dns_name"></a> [dns\_name](#output\_dns\_name) | The DNS name of the NLB. |
 | <a name="output_ready"></a> [ready](#output\_ready) | Hack! Because modules with providers (cluster-apps) cannot use depends\_on output value needs to be used to make sure those are provisioned in correct order. |

--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,10 @@ resource "aws_lb_listener" "tls" {
   })
 
   lifecycle {
+    precondition {
+      condition     = var.acm_arn != null
+      error_message = "acm_arn is required when the default TLS listener is enabled."
+    }
     ignore_changes = [tags_all]
   }
 }
@@ -86,7 +90,7 @@ resource "aws_security_group" "nlb" {
 }
 
 resource "aws_lb_listener_certificate" "extra" {
-  count           = var.create_default_listeners ? length(var.acm_extra_arns) : 0
+  count           = var.create_default_listeners && var.create_default_tls_listener ? length(var.acm_extra_arns) : 0
   listener_arn    = aws_lb_listener.tls[0].arn
   certificate_arn = element(var.acm_extra_arns, count.index)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,10 +27,11 @@ variable "application" {
 }
 
 variable "acm_arn" {
-  description = "ARN for ACM certificate used for TLS"
+  description = "ARN for ACM certificate used for TLS. Required when the default TLS listener is enabled."
   type        = string
+  default     = null
   validation {
-    condition     = can(regex("^arn:aws:acm:[a-z][a-z]-[a-z]+-[1-9]:\\d{12}:certificate/[A-Za-z0-9\\-]+$", var.acm_arn))
+    condition     = var.acm_arn == null || can(regex("^arn:aws:acm:[a-z][a-z]-[a-z]+-[1-9]:\\d{12}:certificate/[A-Za-z0-9\\-]+$", var.acm_arn))
     error_message = "Invalid ACM ARN"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 }


### PR DESCRIPTION
## Requestor/Issue

INFRA-6096

## Tested (yes/no)

no (needs `terraform plan` in a project that uses this module with `create_default_tls_listener = false`)

## Description/Why

Both ALB and NLB modules require `acm_arn` as mandatory input even when listeners are disabled. This forces callers to provide a dummy ACM ARN for deployments that don't use HTTPS/TLS listeners (e.g. when listeners are managed externally by AWS Gateway API controller).

Changes:
- `variables.tf`: `acm_arn` now optional (`default = null`) with regex validation accepting `null` or a valid ACM ARN
- `main.tf`: `precondition` on `aws_lb_listener.tls` ensures `acm_arn` is non-null when TLS listener is enabled; fixed `aws_lb_listener_certificate.extra` count to also check `create_default_tls_listener`
- `README.md`: added example showing `acm_arn` omitted with `create_default_tls_listener = false`

Backward compatible — existing callers passing `acm_arn` are unaffected.

## AI usage/prompt(s) (if applicable)

OpenCode (claude-opus-4.6) — prompted to implement INFRA-6096 based on the Linear issue description.