### PR TITLE
chore: SHA-pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/terraform-test.yml
+++ b/.github/workflows/terraform-test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: terraform test
         uses: dflook/terraform-test@58481fc46588861db38966e076b8481402817b91


### PR DESCRIPTION
Requestor/Issue: @tomasz.charewicz (no ticket provided)

Tested (yes/no): no (workflow-only change; verification is observing CI on this PR — affected job(s) need to come up green)

Description/Why:
SHA-pins the remaining tag/branch refs (`@master`, `@v6.0.2`, `@v6`, `@v4`) on third-party GitHub Actions used in this repo's workflows. Content-addressed SHA pinning prevents tag-rewrite supply-chain attacks: a compromised upstream maintainer (or an attacker with push access) can move a tag at any time, but a SHA is immutable.

Part of a fleet-wide audit across 18 `worldcoin/terraform-*` repos — 17 had unpinned third-party refs (typically `actions/checkout@master`, `actions/checkout@v6.0.2`, or `github/codeql-action/upload-sarif@v4`). Sibling PRs being opened in parallel across the affected repos so the fleet is consistent.

Scope: third-party actions only. `worldcoin/gh-actions*` and `worldcoin/gh-actions-public*` refs are intentionally left as `@main` — separate cleanup, also pending fleet-wide.

SHAs used (current latest of their majors at audit time):
- `actions/checkout` v6.0.2 → `de0fac2e4500dabe0009e67214ff5f5447ce83dd`
- `github/codeql-action/upload-sarif` v4.35.5 → `9e0d7b8d25671d64c341c19c0152d693099fb5ba`